### PR TITLE
adding anti-affinity to control plane objects

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -30,6 +30,17 @@ spec:
         app: controller
         discovery.knative.dev/release: devel
     spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+
       serviceAccountName: controller
       containers:
       - name: controller
@@ -37,11 +48,9 @@ spec:
         # and substituted here.
         image: ko://knative.dev/discovery/cmd/controller
         resources:
-          # Request 2x what we saw running e2e
           requests:
             cpu: 100m
             memory: 100Mi
-          # Limit to 10x the request (20x the observed peak during e2e)
           limits:
             cpu: 1000m
             memory: 1000Mi

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -32,6 +32,17 @@ spec:
         role: webhook
         discovery.knative.dev/release: devel
     spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: webhook
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+
       serviceAccountName: controller
       containers:
       - name: webhook
@@ -39,11 +50,9 @@ spec:
         # and substituted here.
         image: ko://knative.dev/discovery/cmd/webhook
         resources:
-          # Request 2x what we saw running e2e
           requests:
             cpu: 20m
             memory: 20Mi
-          # Limit to 10x the request (20x the observed peak during e2e)
           limits:
             cpu: 200m
             memory: 200Mi


### PR DESCRIPTION
This makes sure if the control plane scales, it does not scale on the same node as the other replicas for the control plane.

fixes https://github.com/knative-sandbox/discovery/issues/4
fixes https://github.com/knative-sandbox/discovery/issues/34