### PR TITLE
introduce the resource mapper

### DIFF
--- a/pkg/collection/ducks.go
+++ b/pkg/collection/ducks.go
@@ -24,7 +24,7 @@ import (
 	"knative.dev/discovery/pkg/apis/discovery/v1alpha1"
 )
 
-// DuckHunter is used to collect, sort and bucket Kubernetes resources. This is
+// DuckHunter is used to collect, sort and bucket Kubernetes mappings. This is
 // based on adding CRDs and inspecting labels and annotations, or by adding
 // references directly. The DuckHunter will determine which version of the
 // duck type should be used for each kind of Add function. The current collection
@@ -60,8 +60,9 @@ type DuckFilters struct {
 
 // NewDuckHunter
 // versions are used to default all the DuckType versions that apply to unfiltered CRDs.
-func NewDuckHunter(versions []v1alpha1.DuckVersion, filters *DuckFilters) DuckHunter {
+func NewDuckHunter(mapper ResourceMapper, versions []v1alpha1.DuckVersion, filters *DuckFilters) DuckHunter {
 	dh := &duckHunter{
+		mapper:   mapper,
 		filters:  filters,
 		versions: make([]string, 0),
 		ducks:    make(map[string][]v1alpha1.ResourceMeta, len(versions)),
@@ -79,6 +80,10 @@ func NewDuckHunter(versions []v1alpha1.DuckVersion, filters *DuckFilters) DuckHu
 
 // duckHunter is an internal implementation of the duck hunter logic.
 type duckHunter struct {
+	// mapper is used to convert between resource and kind, and validate
+	// resources exist on the cluster.
+	mapper ResourceMapper
+
 	filters *DuckFilters
 	// versions are the versions to use for unfiltered CRDs being added to the ducks map.
 	versions []string

--- a/pkg/collection/ducks_test.go
+++ b/pkg/collection/ducks_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package collection
 
 import (
@@ -91,7 +107,7 @@ func TestNewDuckHunter(t *testing.T) {
 		}}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			if got := NewDuckHunter(tc.versions, nil); !reflect.DeepEqual(got, tc.want) {
+			if got := NewDuckHunter(nil, tc.versions, nil); !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("NewDuckHunter() = %v, want %v", got, tc.want)
 			}
 		})
@@ -105,7 +121,7 @@ func Test_DuckHunter_AddCRD(t *testing.T) {
 		want map[string][]v1alpha1.ResourceMeta
 	}{
 		"one duck version, one crd version": {
-			dh:  NewDuckHunter([]v1alpha1.DuckVersion{{Name: "v1"}}, nil),
+			dh:  NewDuckHunter(nil, []v1alpha1.DuckVersion{{Name: "v1"}}, nil),
 			crd: makeCRD("teach.me.how", "Ducky", map[string]bool{"v2": true}),
 			want: map[string][]v1alpha1.ResourceMeta{
 				"v1": {{
@@ -116,7 +132,7 @@ func Test_DuckHunter_AddCRD(t *testing.T) {
 			},
 		},
 		"one duck version, two crd version": {
-			dh:  NewDuckHunter([]v1alpha1.DuckVersion{{Name: "v1"}}, nil),
+			dh:  NewDuckHunter(nil, []v1alpha1.DuckVersion{{Name: "v1"}}, nil),
 			crd: makeCRD("teach.me.how", "Ducky", map[string]bool{"v2": true, "v3": true}),
 			want: map[string][]v1alpha1.ResourceMeta{
 				"v1": {{
@@ -131,7 +147,7 @@ func Test_DuckHunter_AddCRD(t *testing.T) {
 			},
 		},
 		"three duck versions, one crd version": {
-			dh:  NewDuckHunter([]v1alpha1.DuckVersion{{Name: "v1"}, {Name: "v2"}, {Name: "v3"}}, nil),
+			dh:  NewDuckHunter(nil, []v1alpha1.DuckVersion{{Name: "v1"}, {Name: "v2"}, {Name: "v3"}}, nil),
 			crd: makeCRD("teach.me.how", "Ducky", map[string]bool{"v2": true}),
 			want: map[string][]v1alpha1.ResourceMeta{
 				"v1": {{
@@ -169,7 +185,7 @@ func Test_DuckHunter_AddCRD_filtered(t *testing.T) {
 		want map[string][]v1alpha1.ResourceMeta
 	}{
 		"match filter": {
-			dh: NewDuckHunter(nil, &DuckFilters{
+			dh: NewDuckHunter(nil, nil, &DuckFilters{
 				DuckLabel:         "teach.me.how/ducky",
 				DuckVersionPrefix: "duckies.teach.me.how",
 			}),
@@ -184,7 +200,7 @@ func Test_DuckHunter_AddCRD_filtered(t *testing.T) {
 			},
 		},
 		"one matching version of two": {
-			dh: NewDuckHunter(nil, &DuckFilters{
+			dh: NewDuckHunter(nil, nil, &DuckFilters{
 				DuckLabel:         "teach.me.how/ducky",
 				DuckVersionPrefix: "duckies.teach.me.how",
 			}),
@@ -199,7 +215,7 @@ func Test_DuckHunter_AddCRD_filtered(t *testing.T) {
 			},
 		},
 		"twp matching version of two": {
-			dh: NewDuckHunter(nil, &DuckFilters{
+			dh: NewDuckHunter(nil, nil, &DuckFilters{
 				DuckLabel:         "teach.me.how/ducky",
 				DuckVersionPrefix: "duckies.teach.me.how",
 			}),
@@ -219,7 +235,7 @@ func Test_DuckHunter_AddCRD_filtered(t *testing.T) {
 			},
 		},
 		"no match": {
-			dh: NewDuckHunter(nil, &DuckFilters{
+			dh: NewDuckHunter(nil, nil, &DuckFilters{
 				DuckLabel:         "teach.me.how/ducky",
 				DuckVersionPrefix: "duckies.teach.me.how",
 			}),
@@ -248,7 +264,7 @@ func Test_DuckHunter_AddRef(t *testing.T) {
 		want        map[string][]v1alpha1.ResourceMeta
 	}{
 		"GVK, one duck type version": {
-			dh:          NewDuckHunter([]v1alpha1.DuckVersion{{Name: "v1"}}, nil),
+			dh:          NewDuckHunter(nil, []v1alpha1.DuckVersion{{Name: "v1"}}, nil),
 			duckVersion: "v1",
 			ref: v1alpha1.ResourceRef{
 				Group:   "teach.me.how",

--- a/pkg/collection/resources.go
+++ b/pkg/collection/resources.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collection
+
+import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ResourceMapper can be used to convert between Resource and Kind or validate
+// a Resource or Kind at a GroupVersion exists on the cluster.
+type ResourceMapper interface {
+	// KindExists returns true if the given kind is known for the given
+	// groupVersion.
+	KindExists(groupVersion, kind string) bool
+	// ResourceExists returns true if the given resource is known for the given
+	// GroupVersion.
+	ResourceExists(groupVersion, resource string) bool
+	// KindFor returns the Kind for the given resource in the given
+	// GroupVersion.
+	KindFor(groupVersion, resource string) (string, error)
+	// ResourceFor returns the Kind for the given kind in the given
+	// GroupVersion.
+	ResourceFor(groupVersion, kind string) (string, error)
+}
+
+// NewResourceMapper processes a list of APIResourceLists and creates a
+// ResourceMapper that can be used to convert between Resource and Kind or
+// validate a Resource or Kind at a GroupVersion exists on the cluster.
+func NewResourceMapper(apiGroups []*metav1.APIResourceList) ResourceMapper {
+	mappings := make(map[string]mapping)
+
+	for _, apiGroup := range apiGroups {
+		mappings[apiGroup.GroupVersion] = mapping{
+			r2k: make(map[string]string, 0),
+			k2r: make(map[string]string, 0),
+		}
+
+		for _, apiResource := range apiGroup.APIResources {
+			// the API groups contains all the endpoints, we don't want the
+			//sub mappings for now. We will skip.
+			if strings.Contains(apiResource.Name, "/") {
+				continue
+			}
+			mappings[apiGroup.GroupVersion].k2r[apiResource.Kind] = apiResource.Name
+			mappings[apiGroup.GroupVersion].r2k[apiResource.Name] = apiResource.Kind
+		}
+	}
+	return &resourceMapper{mappings: mappings}
+}
+
+type resourceMapper struct {
+	mappings map[string]mapping
+}
+
+type mapping struct {
+	r2k map[string]string
+	k2r map[string]string
+}
+
+// KindExists implements ResourceMapper.KindExists
+func (rm *resourceMapper) KindExists(groupVersion, kind string) bool {
+	m, found := rm.mappings[groupVersion]
+	if !found {
+		return false
+	}
+	_, found = m.k2r[kind]
+	return found
+}
+
+// ResourceExists implements ResourceMapper.ResourceExists
+func (rm *resourceMapper) ResourceExists(groupVersion, resource string) bool {
+	m, found := rm.mappings[groupVersion]
+	if !found {
+		return false
+	}
+	_, found = m.r2k[resource]
+	return found
+}
+
+// KindFor implements ResourceMapper.KindFor
+func (rm *resourceMapper) KindFor(groupVersion, resource string) (string, error) {
+	m, found := rm.mappings[groupVersion]
+	if !found {
+		return "", fmt.Errorf("kind not found for %s in %s", resource, groupVersion)
+	}
+	kind, found := m.r2k[resource]
+	if !found {
+		return "", fmt.Errorf("kind not found for %s in %s", resource, groupVersion)
+	}
+	return kind, nil
+}
+
+// ResourceFor implements ResourceMapper.ResourceFor
+func (rm *resourceMapper) ResourceFor(groupVersion, kind string) (string, error) {
+	m, found := rm.mappings[groupVersion]
+	if !found {
+		return "", fmt.Errorf("resource not found for %s in %s", kind, groupVersion)
+	}
+	resource, found := m.k2r[kind]
+	if !found {
+		return "", fmt.Errorf("resource not found for %s in %s", kind, groupVersion)
+	}
+	return resource, nil
+
+}

--- a/pkg/collection/resources_test.go
+++ b/pkg/collection/resources_test.go
@@ -1,0 +1,352 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collection
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewResourceMapper(t *testing.T) {
+	tests := map[string]struct {
+		apis []*metav1.APIResourceList
+		want *resourceMapper
+	}{
+		"one api, one resource": {
+			apis: []*metav1.APIResourceList{
+				{
+					GroupVersion: "swan.lake/v1",
+					APIResources: []metav1.APIResource{{
+						Name:       "ballets",
+						Namespaced: false,
+						Kind:       "Ballet",
+					}},
+				}},
+			want: &resourceMapper{
+				mappings: map[string]mapping{
+					"swan.lake/v1": {
+						r2k: map[string]string{"ballets": "Ballet"},
+						k2r: map[string]string{"Ballet": "ballets"},
+					},
+				},
+			},
+		},
+		"one api, one resource, one sub resource": {
+			apis: []*metav1.APIResourceList{
+				{
+					GroupVersion: "swan.lake/v1",
+					APIResources: []metav1.APIResource{{
+						Name:       "ballets",
+						Namespaced: false,
+						Kind:       "Ballet",
+					}, {
+						Name:       "ballets/status",
+						Namespaced: false,
+						Kind:       "Ballet",
+					}},
+				}},
+			want: &resourceMapper{
+				mappings: map[string]mapping{
+					"swan.lake/v1": {
+						r2k: map[string]string{"ballets": "Ballet"},
+						k2r: map[string]string{"Ballet": "ballets"},
+					},
+				},
+			},
+		},
+		"one api, two resources": {
+			apis: []*metav1.APIResourceList{
+				{
+					GroupVersion: "swan.lake/v1",
+					APIResources: []metav1.APIResource{{
+						Name: "ballets",
+						Kind: "Ballet",
+					}, {
+						Name: "shoes",
+						Kind: "Shoe",
+					}},
+				}},
+			want: &resourceMapper{
+				mappings: map[string]mapping{
+					"swan.lake/v1": {
+						r2k: map[string]string{"ballets": "Ballet", "shoes": "Shoe"},
+						k2r: map[string]string{"Ballet": "ballets", "Shoe": "shoes"},
+					},
+				},
+			},
+		},
+		"two api, three resources": {
+			apis: []*metav1.APIResourceList{
+				{
+					GroupVersion: "swan.lake/v1",
+					APIResources: []metav1.APIResource{{
+						Name: "ballets",
+						Kind: "Ballet",
+					}, {
+						Name: "shoes",
+						Kind: "Shoe",
+					}},
+				}, {
+					GroupVersion: "duck.lake/v2",
+					APIResources: []metav1.APIResource{{
+						Name: "breads",
+						Kind: "Bread",
+					}},
+				}},
+			want: &resourceMapper{
+				mappings: map[string]mapping{
+					"duck.lake/v2": {
+						r2k: map[string]string{"breads": "Bread"},
+						k2r: map[string]string{"Bread": "breads"},
+					},
+					"swan.lake/v1": {
+						r2k: map[string]string{"ballets": "Ballet", "shoes": "Shoe"},
+						k2r: map[string]string{"Ballet": "ballets", "Shoe": "shoes"},
+					},
+				},
+			},
+		}}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := NewResourceMapper(tc.apis); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("NewDuckHunter() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResourceFor(t *testing.T) {
+	rm := &resourceMapper{
+		mappings: map[string]mapping{
+			"swan.lake/v1": {
+				r2k: map[string]string{"ballets": "Ballet", "shoes": "Shoe"},
+				k2r: map[string]string{"Ballet": "ballets", "Shoe": "shoes"},
+			},
+			"duck.lake/v2": {
+				r2k: map[string]string{"breads": "Bread"},
+				k2r: map[string]string{"Bread": "breads"},
+			},
+		}}
+
+	tests := map[string]struct {
+		rm           ResourceMapper
+		groupVersion string
+		kind         string
+		want         string
+		wantErr      bool
+	}{
+		"duck lake Bread->breads": {
+			rm:           rm,
+			groupVersion: "duck.lake/v2",
+			kind:         "Bread",
+			want:         "breads",
+		},
+		"wrong kind casing breads->Bread": {
+			rm:           rm,
+			groupVersion: "duck.lake/v2",
+			kind:         "breads",
+			wantErr:      true,
+		},
+		"duck lake Ballet->error": {
+			rm:           rm,
+			groupVersion: "duck.lake/v2",
+			kind:         "Ballet",
+			wantErr:      true,
+		},
+		"unknown Shoe->error": {
+			rm:           rm,
+			groupVersion: "data.lake/v3",
+			kind:         "Shoe",
+			wantErr:      true,
+		}}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := tc.rm.ResourceFor(tc.groupVersion, tc.kind)
+			if err != nil {
+				if !tc.wantErr {
+					t.Errorf("expected error calling rm.ResourceFor(%q, %q): %v", tc.groupVersion, tc.kind, err)
+				}
+			} else if got != tc.want {
+				t.Errorf("rm.ResourceFor(%q, %q) = %v, want %v", tc.groupVersion, tc.kind, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKindExists(t *testing.T) {
+	rm := &resourceMapper{
+		mappings: map[string]mapping{
+			"swan.lake/v1": {
+				r2k: map[string]string{"ballets": "Ballet", "shoes": "Shoe"},
+				k2r: map[string]string{"Ballet": "ballets", "Shoe": "shoes"},
+			},
+			"duck.lake/v2": {
+				r2k: map[string]string{"breads": "Bread"},
+				k2r: map[string]string{"Bread": "breads"},
+			},
+		}}
+
+	tests := map[string]struct {
+		rm           ResourceMapper
+		groupVersion string
+		kind         string
+		want         bool
+	}{
+		"duck lake Bread->breads": {
+			rm:           rm,
+			groupVersion: "duck.lake/v2",
+			kind:         "Bread",
+			want:         true,
+		},
+		"wrong kind casing breads->Bread": {
+			rm:           rm,
+			groupVersion: "duck.lake/v2",
+			kind:         "breads",
+			want:         false,
+		},
+		"duck lake Ballet->error": {
+			rm:           rm,
+			groupVersion: "duck.lake/v2",
+			kind:         "Ballet",
+			want:         false,
+		},
+		"unknown Shoe->error": {
+			rm:           rm,
+			groupVersion: "data.lake/v3",
+			kind:         "Shoe",
+			want:         false,
+		}}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tc.rm.KindExists(tc.groupVersion, tc.kind); got != tc.want {
+				t.Errorf("rm.KindExists(%q, %q) = %v, want %v", tc.groupVersion, tc.kind, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKindFor(t *testing.T) {
+	rm := &resourceMapper{
+		mappings: map[string]mapping{
+			"swan.lake/v1": {
+				r2k: map[string]string{"ballets": "Ballet", "shoes": "Shoe"},
+				k2r: map[string]string{"Ballet": "ballets", "Shoe": "shoes"},
+			},
+			"duck.lake/v2": {
+				r2k: map[string]string{"breads": "Bread"},
+				k2r: map[string]string{"Bread": "breads"},
+			},
+		}}
+
+	tests := map[string]struct {
+		rm           ResourceMapper
+		groupVersion string
+		resource     string
+		want         string
+		wantErr      bool
+	}{
+		"duck lake breads->Bread": {
+			rm:           rm,
+			groupVersion: "duck.lake/v2",
+			resource:     "breads",
+			want:         "Bread",
+		},
+		"wrong resource casing Bread->breads": {
+			rm:           rm,
+			groupVersion: "duck.lake/v2",
+			resource:     "Bread",
+			wantErr:      true,
+		},
+		"duck lake ballets->error": {
+			rm:           rm,
+			groupVersion: "duck.lake/v2",
+			resource:     "ballet",
+			wantErr:      true,
+		},
+		"unknown Shoe->error": {
+			rm:           rm,
+			groupVersion: "data.lake/v3",
+			resource:     "shoe",
+			wantErr:      true,
+		}}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := tc.rm.KindFor(tc.groupVersion, tc.resource)
+			if err != nil {
+				if !tc.wantErr {
+					t.Errorf("expected error calling rm.KindFor(%q, %q): %v", tc.groupVersion, tc.resource, err)
+				}
+			} else if got != tc.want {
+				t.Errorf("rm.KindFor(%q, %q) = %v, want %v", tc.groupVersion, tc.resource, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResourceExists(t *testing.T) {
+	rm := &resourceMapper{
+		mappings: map[string]mapping{
+			"swan.lake/v1": {
+				r2k: map[string]string{"ballets": "Ballet", "shoes": "Shoe"},
+				k2r: map[string]string{"Ballet": "ballets", "Shoe": "shoes"},
+			},
+			"duck.lake/v2": {
+				r2k: map[string]string{"breads": "Bread"},
+				k2r: map[string]string{"Bread": "breads"},
+			},
+		}}
+
+	tests := map[string]struct {
+		rm           ResourceMapper
+		groupVersion string
+		resource     string
+		want         bool
+	}{
+		"duck lake breads": {
+			rm:           rm,
+			groupVersion: "duck.lake/v2",
+			resource:     "breads",
+			want:         true,
+		},
+		"wrong resource casing Bread": {
+			rm:           rm,
+			groupVersion: "duck.lake/v2",
+			resource:     "Bread",
+			want:         false,
+		},
+		"duck lake ballets->error": {
+			rm:           rm,
+			groupVersion: "duck.lake/v2",
+			resource:     "ballets",
+			want:         false,
+		},
+		"unknown Shoe->error": {
+			rm:           rm,
+			groupVersion: "data.lake/v3",
+			resource:     "shoe",
+			want:         false,
+		}}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tc.rm.ResourceExists(tc.groupVersion, tc.resource); got != tc.want {
+				t.Errorf("rm.ResourceExists(%q, %q) = %v, want %v", tc.groupVersion, tc.resource, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/clusterducktype/clusterducktype.go
+++ b/pkg/reconciler/clusterducktype/clusterducktype.go
@@ -19,11 +19,15 @@ package clusterducktype
 import (
 	"context"
 	"fmt"
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
 	"strings"
+	"sync"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionslisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
 	"knative.dev/discovery/pkg/collection"
 
 	v1alpha1 "knative.dev/discovery/pkg/apis/discovery/v1alpha1"
@@ -34,7 +38,11 @@ import (
 // Reconciler implements ducktypereconciler.Interface for
 // ClusterDuckType resources.
 type Reconciler struct {
+	client    kubernetes.Interface
 	crdLister apiextensionslisters.CustomResourceDefinitionLister
+
+	resourceMapper collection.ResourceMapper
+	rmx            sync.Mutex
 }
 
 // Check that our Reconciler implements Interface
@@ -42,7 +50,9 @@ var _ ducktypereconciler.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface
 func (r *Reconciler) ReconcileKind(ctx context.Context, dt *v1alpha1.ClusterDuckType) reconciler.Event {
-	hunter := collection.NewDuckHunter(nil, &collection.DuckFilters{
+	// TODO: I might want to wrap this entire call with a rmx lock, but it will block the other threads.
+	// To prevent this, we could copy the resourceMapper?
+	hunter := collection.NewDuckHunter(r.resourceMapper, nil, &collection.DuckFilters{
 		DuckLabel:         fmt.Sprintf("%s/%s", dt.Spec.Group, dt.Spec.Names.Singular),
 		DuckVersionPrefix: fmt.Sprintf("%s.%s", dt.Spec.Names.Plural, dt.Spec.Group),
 	})
@@ -88,6 +98,21 @@ func (r *Reconciler) getCRDsWith(labelSelector string) ([]*apiextensionsv1.Custo
 	}
 
 	return list, nil
+}
+
+// resyncResourceMapper will make a call to the Kubernetes APIServer to request
+// the full list of resources on this cluster and then process the list to
+// create a lookup table between GroupVersions, Kinds and Resources.
+func (r *Reconciler) resyncResourceMapper(ctx context.Context) {
+	r.rmx.Lock()
+	defer r.rmx.Unlock()
+
+	_, apiResources, err := r.client.Discovery().ServerGroupsAndResources()
+	if err != nil {
+		logging.FromContext(ctx).Errorf("Failed to resync resource mapper.", zap.Error(err))
+		return
+	}
+	r.resourceMapper = collection.NewResourceMapper(apiResources)
 }
 
 // DuckCount de-dupes the number of ducks inside the mapped collection of found

--- a/pkg/reconciler/clusterducktype/controller.go
+++ b/pkg/reconciler/clusterducktype/controller.go
@@ -58,8 +58,3 @@ func NewController(
 
 	return impl
 }
-
-type ResourceMapping struct {
-	ResourceToKind map[string]string
-	KindToResource map[string]string
-}

--- a/pkg/reconciler/clusterducktype/controller.go
+++ b/pkg/reconciler/clusterducktype/controller.go
@@ -19,13 +19,13 @@ package clusterducktype
 import (
 	"context"
 
-	"knative.dev/pkg/configmap"
-	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
-
 	ducktypeinformer "knative.dev/discovery/pkg/client/injection/informers/discovery/v1alpha1/clusterducktype"
 	ducktypereconciler "knative.dev/discovery/pkg/client/injection/reconciler/discovery/v1alpha1/clusterducktype"
 	crdinformer "knative.dev/pkg/client/injection/apiextensions/informers/apiextensions/v1/customresourcedefinition"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
 )
 
 // NewController creates a Reconciler and returns the result of NewImpl.
@@ -38,11 +38,11 @@ func NewController(
 	ducktypeInformer := ducktypeinformer.Get(ctx)
 	crdInformer := crdinformer.Get(ctx)
 
-	// TODO: watch CRDs, etc.
-
 	r := &Reconciler{
+		client:    kubeclient.Get(ctx),
 		crdLister: crdInformer.Lister(),
 	}
+	r.resyncResourceMapper(ctx)
 	impl := ducktypereconciler.NewImpl(ctx, r)
 
 	logger.Info("Setting up event handlers.")
@@ -51,9 +51,15 @@ func NewController(
 
 	// Watch custom resource definitions.
 	grDt := func(obj interface{}) {
+		r.resyncResourceMapper(ctx)
 		impl.GlobalResync(ducktypeInformer.Informer())
 	}
 	crdInformer.Informer().AddEventHandler(controller.HandleAll(grDt))
 
 	return impl
+}
+
+type ResourceMapping struct {
+	ResourceToKind map[string]string
+	KindToResource map[string]string
 }


### PR DESCRIPTION
I wrote a little thing to be able to understand all the installed types in kubernetes, and also am able to map between kind and resource. This lets us give refs for versions of resources that are not installed and then not let them show up in the status of a ClusterDuckType, because they did not match anything valid in the cluster. NEAT. We might also want to use this to help map Kind to Resource in our other obj refs… can upstream somewhere if that is interesting.