### PR TITLE
[Automated] Fix misspellings

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -217,7 +217,7 @@ function wait_for_file() {
   waits=300
   timeout=$waits
 
-  echo "Waiting for existance of file: ${file}"
+  echo "Waiting for existence of file: ${file}"
 
   while [ ! -f "${file}" ]; do
     # When the timeout is equal to zero, show an error and leave the loop.


### PR DESCRIPTION
Produced via:
```shell
export FILES=( $(find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*') )
misspell -w "${FILES[@]}"
```
/cc n3wscott vaikas
/assign n3wscott vaikas