### PR TITLE
[#171] Update test/kind/bootstrap

### DIFF
--- a/test/kind/README.md
+++ b/test/kind/README.md
@@ -3,6 +3,8 @@
 The following is what is needed to use KinD to run the e2e tests. Base path is
 assumed to be the top level project.
 
+See .github/workflows/kind-e2e.yaml for minimum kind version
+
 Startup a cluster:
 
 ```shell

--- a/test/kind/bootstrap.sh
+++ b/test/kind/bootstrap.sh
@@ -29,7 +29,6 @@ set -o errexit
 cluster_name=knik
 reg_name='kind-registry'
 reg_port='5000'
-node_image='kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765'
 
 # Parse flags to determine any we should pass to dep.
 check=0
@@ -101,9 +100,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: ${node_image}
 - role: worker
-  image: ${node_image}
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]


### PR DESCRIPTION
Fixes #171 

# Changes
- :broom: remove hardcoded ref to old k8s version which controllers don't run on
  anymore. Update the kind yaml to look more like github workflow
  kind-e2e.yaml which doesn't specify a kind image version.

/kind bug



