### PR TITLE
[#177] Update ClusterDuckType openAPI schema

### DIFF
--- a/config/300-clusterducktype.yaml
+++ b/config/300-clusterducktype.yaml
@@ -52,6 +52,25 @@ spec:
                     singular:
                       description: Singular is the singular name of the duck type. It must be all lowercase. Defaults to lowercased `name`.
                       type: string
+                role:
+                  description: Role holds an Aggregating Role used by the duck type to manage the ducks. If not specified, the Selectors are used to find a Role with an aggregation rule that matches a selector
+                  type: object
+                  required:
+                    - roleRef
+                  properties:
+                    roleRef:
+                      description: RoleRef is a reference to the Aggregating Role
+                      type: object
+                      properties:
+                        apiGroup:
+                          description: APIGroup is the group for the resource being referenced
+                          type: string
+                        kind:
+                          description: Kind is the type of resource being referenced
+                          type: string
+                        name:
+                          description: Name is the name of resource being referenced
+                          type: string
                 selectors:
                   description: Selectors is a list of selectors for CustomResourceDefinitions to identify a duck type.
                   type: array
@@ -266,6 +285,37 @@ spec:
                   description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                clusterRoleAggregationRule:
+                  description: ClusterRole Aggregation Rule
+                  type: object
+                  properties:
+                    clusterRoleSelectors:
+                      description: ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                 conditions:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array


### PR DESCRIPTION
fixes #177 

# Changes
- :bug: ran "go run ./cmd/schema ClusterDuckType" to generate the schema and
  updated the CDT CRD with the missing ClusterRole fields in spec and
  status. Manually validated that the addressables CO works and displays
  the matched ClusterRole and AggregationRule details
- Didn't add the E2E test in this PR. Will handle it when addressing #175 


