### PR TITLE
[#182] Fix ClusterRole access validation plural bug

### DIFF
--- a/pkg/collection/ducks_test.go
+++ b/pkg/collection/ducks_test.go
@@ -82,6 +82,7 @@ func TestNewDuckHunter(t *testing.T) {
 				defaultVersions:         []string{},
 				ducks:                   map[string][]v1alpha1.ResourceMeta{},
 				accesbileGroupresources: map[string]bool{},
+				kindToResource:          map[string]string{},
 			},
 		},
 		"one defaultVersions": {
@@ -95,6 +96,7 @@ func TestNewDuckHunter(t *testing.T) {
 					"v1": {},
 				},
 				accesbileGroupresources: map[string]bool{},
+				kindToResource:          map[string]string{},
 			},
 		},
 		"non nil mapper": {
@@ -123,6 +125,7 @@ func TestNewDuckHunter(t *testing.T) {
 					"v1": {},
 				},
 				accesbileGroupresources: map[string]bool{},
+				kindToResource:          map[string]string{},
 			},
 		},
 		"three defaultVersions": {
@@ -136,6 +139,7 @@ func TestNewDuckHunter(t *testing.T) {
 					"v3": {},
 				},
 				accesbileGroupresources: map[string]bool{},
+				kindToResource:          map[string]string{},
 			},
 		},
 		"overlapping defaultVersions": {
@@ -150,6 +154,7 @@ func TestNewDuckHunter(t *testing.T) {
 					"v2": {},
 				},
 				accesbileGroupresources: map[string]bool{},
+				kindToResource:          map[string]string{},
 			},
 		}}
 	for name, tc := range tests {
@@ -183,7 +188,7 @@ func Test_DuckHunter_AddCRD(t *testing.T) {
 				Rules: []rbacv1.PolicyRule{{
 					Verbs:     []string{rbacv1.VerbAll},
 					APIGroups: []string{"teach.me.how"},
-					Resources: []string{"Duckys"},
+					Resources: []string{"duckies"},
 				}},
 			}),
 			crd: makeCRD("teach.me.how", "Ducky", map[string]bool{"v2": true}),
@@ -219,7 +224,7 @@ func Test_DuckHunter_AddCRD(t *testing.T) {
 				Rules: []rbacv1.PolicyRule{{
 					Verbs:     []string{rbacv1.VerbAll},
 					APIGroups: []string{"*"},
-					Resources: []string{"Duckys"},
+					Resources: []string{"duckies"},
 				}},
 			}),
 			crd: makeCRD("teach.me.how", "Ducky", map[string]bool{"v2": true}),
@@ -255,7 +260,7 @@ func Test_DuckHunter_AddCRD(t *testing.T) {
 				Rules: []rbacv1.PolicyRule{{
 					Verbs:     []string{"get"},
 					APIGroups: []string{"teach.me.how"},
-					Resources: []string{"Duckys"},
+					Resources: []string{"duckies"},
 				}},
 			}),
 			crd: makeCRD("teach.me.how", "Ducky", map[string]bool{"v2": true}),
@@ -525,15 +530,16 @@ func Test_DuckHunter_AddRef(t *testing.T) {
 				Rules: []rbacv1.PolicyRule{{
 					Verbs:     []string{rbacv1.VerbAll},
 					APIGroups: []string{"teach.me.how"},
-					Resources: []string{"Duckys"},
+					Resources: []string{"duckies"},
 				}},
 			}),
 			duckVersion: "v1",
 			ref: v1alpha1.ResourceRef{
-				Group:   "teach.me.how",
-				Version: "v2",
-				Kind:    "Ducky",
-				Scope:   "Namespaced",
+				Group:    "teach.me.how",
+				Version:  "v2",
+				Kind:     "Ducky",
+				Scope:    "Namespaced",
+				Resource: "Duckies",
 			},
 			want: map[string][]v1alpha1.ResourceMeta{
 				"v1": {{
@@ -549,7 +555,7 @@ func Test_DuckHunter_AddRef(t *testing.T) {
 				Rules: []rbacv1.PolicyRule{{
 					Verbs:     []string{"watch"},
 					APIGroups: []string{"teach.me.how"},
-					Resources: []string{"Duckys"},
+					Resources: []string{"duckies"},
 				}},
 			}),
 			duckVersion: "v1",

--- a/pkg/reconciler/clusterducktype/testdata/config/zoo/clusterroles.yaml
+++ b/pkg/reconciler/clusterducktype/testdata/config/zoo/clusterroles.yaml
@@ -15,3 +15,23 @@ rules:
   - get
   - list
   - watch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: furries-resolver
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      zoo.knative.dev/furries: "true"
+rules:
+- apiGroups:
+  - australia
+  resources:
+  - platypi
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/reconciler/clusterducktype/testdata/config/zoo/initial.yaml
+++ b/pkg/reconciler/clusterducktype/testdata/config/zoo/initial.yaml
@@ -29,7 +29,11 @@ metadata:
 spec:
   selectors:
     - labelSelector: "zoo.knative.dev/furry=true"
-
+  role:
+    roleRef:
+      kind: ClusterRole
+      name: furries-resolver
+      apiGroup: rbac.authorization.k8s.io
   names:
     name: "Furry"
     plural: "furries"

--- a/pkg/reconciler/clusterducktype/testdata/config/zoo/updated-furries.yaml
+++ b/pkg/reconciler/clusterducktype/testdata/config/zoo/updated-furries.yaml
@@ -6,12 +6,15 @@ metadata:
 spec:
   selectors:
     - labelSelector: "zoo.knative.dev/furry=true"
-
   names:
     name: "Furry"
     plural: "furries"
     singular: "furry"
-
+  role:
+    roleRef:
+      kind: ClusterRole
+      name: furries-resolver
+      apiGroup: rbac.authorization.k8s.io
   versions:
     - name: "v1alpha1"
     - name: "v1beta1"
@@ -19,6 +22,10 @@ spec:
 
 status:
   observedGeneration: 0
+  clusterRoleAggregationRule:
+    clusterRoleSelectors:
+    - matchLabels:
+        zoo.knative.dev/furries: "true"
   conditions:
     - type: Ready
       status: "True"
@@ -28,16 +35,21 @@ status:
       - apiVersion: australia/v1alpha2
         kind: Platypus
         scope: Namespaced
+        accessibleByClusterRole: true
       - apiVersion: australia/v1beta1
         kind: Platypus
         scope: Namespaced
+        accessibleByClusterRole: true
       - apiVersion: central.america/v1alpha1
         kind: Monkey
         scope: Namespaced
+        accessibleByClusterRole: false
     v1beta1:
       - apiVersion: australia/v1
         kind: Platypus
         scope: Namespaced
+        accessibleByClusterRole: true
       - apiVersion: central.america/v1alpha1
         kind: Monkey
         scope: Namespaced
+        accessibleByClusterRole: false


### PR DESCRIPTION
# Changes
- :bug: setting the accessibleViaClusterRole flag had a bug if the plural for
  a kind wasn't just appending an "s" (eg. Platypus -> Platypi). Such
  cases weren't handled properly
- :broom: add a feature test to test when explicit ClusterRole is set

fixes #182 