### PR TITLE
update version of kind to default to a higher version of k8s

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Install KinD
       working-directory: ./src/knative.dev/discovery
       env:
-        KIND_VERSION: v0.8.1
+        KIND_VERSION: v0.11.1
       run: |
         set -x
 


### PR DESCRIPTION
old version of kind defaults to 1.18, out of range of support for knative